### PR TITLE
support sending template variables as a serde_json Value blob

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,20 +84,20 @@ impl Message {
         params.insert(String::from("html"), self.html);
 
         // add template
-    if !self.template.is_empty() {
-        params.insert(String::from("template"), self.template);
-        if let Some(template_json) = self.template_json {
-          params.insert(
-            String::from("h:X-Mailgun-Variables"),
-            serde_json::to_string(&template_json).unwrap(),
-          );
-        } else {
-          params.insert(
-            String::from("h:X-Mailgun-Variables"),
-            serde_json::to_string(&self.template_vars).unwrap(),
-          );
+        if !self.template.is_empty() {
+            params.insert(String::from("template"), self.template);
+            if let Some(template_json) = self.template_json {
+                params.insert(
+                    String::from("h:X-Mailgun-Variables"),
+                    serde_json::to_string(&template_json).unwrap(),
+                );
+            } else {
+                params.insert(
+                    String::from("h:X-Mailgun-Variables"),
+                    serde_json::to_string(&self.template_vars).unwrap(),
+                );
+            }
         }
-      }
 
         params
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub struct Message {
     pub html: String,
     pub template: String,
     pub template_vars: HashMap<String, String>,
+    pub template_json: Option<serde_json::Value>,
 }
 
 impl Message {
@@ -83,13 +84,20 @@ impl Message {
         params.insert(String::from("html"), self.html);
 
         // add template
-        if !self.template.is_empty() {
-            params.insert(String::from("template"), self.template);
-            params.insert(
-                String::from("h:X-Mailgun-Variables"),
-                serde_json::to_string(&self.template_vars).unwrap(),
-            );
+    if !self.template.is_empty() {
+        params.insert(String::from("template"), self.template);
+        if let Some(template_json) = self.template_json {
+          params.insert(
+            String::from("h:X-Mailgun-Variables"),
+            serde_json::to_string(&template_json).unwrap(),
+          );
+        } else {
+          params.insert(
+            String::from("h:X-Mailgun-Variables"),
+            serde_json::to_string(&self.template_vars).unwrap(),
+          );
         }
+      }
 
         params
     }


### PR DESCRIPTION
This allows more complex template variables than a `HashMap<String, String>`, support for lists of objects being the primary feature not supported by a basic map like that.

Perhaps could be improved by throwing an error if both json and a template_vars map (with keys) are provided 