### PR TITLE
Adding support for rust tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,21 @@ description = "An unofficial client library for the Mailgun API"
 edition = "2018"
 repository = "https://github.com/dongri/mailgun-rs"
 license = "MIT"
-keywords = ["email","mailgun"]
+keywords = ["email", "mailgun"]
 documentation = "https://docs.rs/mailgun-rs"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.18", features = ["json", "blocking"] }
-serde = { version = "1.0.152",  features = ["derive"] }
+reqwest = { version = "0.11.18", features = [
+    "json",
+    "blocking",
+], default-features = false }
+serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 typed-builder = "0.15.2"
+
+[features]
+default = []
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
This pull request allows `mailgun-rs` to be configured with `rustls-tls` instead of native tls. This is useful for cross compiling to other platforms.