### PR TITLE
Decouple client from message

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ fn send_html(recipient: &str, key: &str, domain: &str) {
     let client = Mailgun {
         api_key: String::from(key),
         domain: String::from(domain),
-        message,
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
 
-    match client.send(MailgunRegion::US, &sender) {
+    match client.send(MailgunRegion::US, &sender, message) {
         Ok(_) => {
             println!("successful");
         }
@@ -79,11 +78,10 @@ fn send_template(recipient: &str, key: &str, domain: &str) {
     let client = Mailgun {
         api_key: String::from(key),
         domain: String::from(domain),
-        message,
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
 
-    match client.send(MailgunRegion::US, &sender) {
+    match client.send(MailgunRegion::US, &sender, message) {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -25,9 +25,6 @@ fn initialize_mailgun(api_key: &str, domain: &str) {
     let mailgun_client = Mailgun {
         api_key: api_key.to_string(),
         domain: domain.to_string(),
-        message: Message {
-            ..Default::default()
-        },
     };
 
     MAILGUN_CLIENT.set(Mutex::new(mailgun_client)).expect("Mailgun client can only be initialized once");
@@ -45,10 +42,12 @@ async fn send_html(recipient: &str) {
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
 
     if let Some(client) = MAILGUN_CLIENT.get() {
-        let mut mailgun_client = client.lock().unwrap();
-        mailgun_client.message = message.clone();
+        let mailgun_client = client.lock().unwrap();
 
-        match mailgun_client.async_send(MailgunRegion::US, &sender).await {
+        match mailgun_client
+            .async_send(MailgunRegion::US, &sender, message)
+            .await
+        {
             Ok(_) => {
                 println!("successful");
             }
@@ -75,10 +74,9 @@ async fn send_template(recipient: &str, key: &str, domain: &str) {
     let client = Mailgun {
         api_key: String::from(key),
         domain: String::from(domain),
-        message,
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.async_send(MailgunRegion::US, &sender).await {
+    match client.async_send(MailgunRegion::US, &sender, message).await {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -23,10 +23,9 @@ fn send_html(recipient: &str, key: &str, domain: &str) {
     let client = Mailgun {
         api_key: String::from(key),
         domain: String::from(domain),
-        message,
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.send(MailgunRegion::US, &sender) {
+    match client.send(MailgunRegion::US, &sender, message) {
         Ok(_) => {
             println!("successful");
         }
@@ -50,10 +49,9 @@ fn send_template(recipient: &str, key: &str, domain: &str) {
     let client = Mailgun {
         api_key: String::from(key),
         domain: String::from(domain),
-        message,
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.send(MailgunRegion::US, &sender) {
+    match client.send(MailgunRegion::US, &sender, message) {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/rocket/src/main.rs
+++ b/examples/rocket/src/main.rs
@@ -69,11 +69,10 @@ fn send_mail_confirmation(order: &Json<Order<'_>>) {
     let client = Mailgun {
         api_key: String::from(api_key),
         domain: String::from(domain),
-        message,
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
 
-    match client.send(&sender) {
+    match client.send(&sender, message) {
         Ok(_) => {
             println!("successful");
         }
@@ -99,11 +98,10 @@ async fn send_mail_confirmation_async(order: &Json<Order<'_>>) {
     let client = Mailgun {
         api_key: String::from(api_key),
         domain: String::from(domain),
-        message,
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
 
-    match client.async_send(&sender).await {
+    match client.async_send(&sender, message).await {
         Ok(_) => {
             println!("successful");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ fn get_base_url(region: MailgunRegion) -> &'static str {
 pub struct Mailgun {
     pub api_key: String,
     pub domain: String,
-    pub message: Message,
 }
 
 pub type SendResult<T> = Result<T, ReqError>;
@@ -34,9 +33,14 @@ pub struct SendResponse {
 }
 
 impl Mailgun {
-    pub fn send(&self, region: MailgunRegion, sender: &EmailAddress) -> SendResult<SendResponse> {
+    pub fn send(
+        &self,
+        region: MailgunRegion,
+        sender: &EmailAddress,
+        message: Message,
+    ) -> SendResult<SendResponse> {
         let client = reqwest::blocking::Client::new();
-        let mut params = self.message.clone().params();
+        let mut params = message.params();
         params.insert("from".to_string(), sender.to_string());
         let url = format!(
             "{}/{}/{}",
@@ -55,13 +59,15 @@ impl Mailgun {
         let parsed: SendResponse = res.json()?;
         Ok(parsed)
     }
+
     pub async fn async_send(
         &self,
         region: MailgunRegion,
         sender: &EmailAddress,
+        message: Message,
     ) -> SendResult<SendResponse> {
         let client = reqwest::Client::new();
-        let mut params = self.message.clone().params();
+        let mut params = message.params();
         params.insert("from".to_string(), sender.to_string());
         let url = format!(
             "{}/{}/{}",


### PR DESCRIPTION
Hi there! 👋 Thank you for this library! It’s been a big help in integrating Mailgun functionality into my project.

While using it, I noticed an opportunity to simplify the API by decoupling the Message structure from the Mailgun client. Previously, the Mailgun client included a message field, which has to be updated with each call to send or send_async.

This change removes the message from the client which is otherwise configuration details, and changes the API to pass the message when calling `send` or `send_async`, instead of updating the client.message field each time.