### PR TITLE
Fix dep reqwest features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.18", features = [
+reqwest = { version = "0.12", features = [
+    "charset",
+    "rustls-tls",
+    "http2",
+    "macos-system-configuration",
     "json",
     "blocking",
 ], default-features = false }


### PR DESCRIPTION
Hi dongri
The current reqwest lacks tls support, so at least one tls feature must be enabled.
Please review, thanks.
