### PR TITLE
feat: add support for attachment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 .env
+sample-file*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "typed-builder",
 ]
 
@@ -960,18 +961,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +172,7 @@ checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -467,10 +479,11 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -516,6 +529,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -664,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64",
  "bytes",
@@ -685,6 +708,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -699,10 +723,13 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "windows-registry",
@@ -770,6 +797,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -997,23 +1030,43 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.2"
+name = "tower"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1062,6 +1115,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1159,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,20 +1182,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -1139,21 +1208,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1161,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1174,15 +1244,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1230,33 +1316,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1334,11 +1425,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1360,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1489,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1396,10 +1515,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1420,6 +1551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1573,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1456,6 +1599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1621,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ reqwest = { version = "0.12", features = [
     "macos-system-configuration",
     "json",
     "blocking",
+    "multipart",
+    "stream",
 ], default-features = false }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "0.12", features = [
 ], default-features = false }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
+thiserror = "2.0.12"
 typed-builder = "0.15.2"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ fn main() {
 
     send_html(recipient, key, domain);
     send_template(recipient, key, domain);
+    send_html_with_attachment(recipient, key, domain);
 }
 
 fn send_html(recipient: &str, key: &str, domain: &str) {
@@ -47,9 +48,8 @@ fn send_html(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
-    match client.send(MailgunRegion::US, &sender, message, attachments) {
+    match client.send(MailgunRegion::US, &sender, message, None) {
         Ok(_) => {
             println!("successful");
         }
@@ -81,9 +81,38 @@ fn send_template(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
-    match client.send(MailgunRegion::US, &sender, message, attachments) {
+    match client.send(MailgunRegion::US, &sender, message, None) {
+        Ok(_) => {
+            println!("successful");
+        }
+        Err(err) => {
+            println!("Error: {err}");
+        }
+    }
+}
+```
+
+#### Send a simple email
+
+```rust
+fn send_html_with_attachment(recipient: &str, key: &str, domain: &str) {
+    let recipient = EmailAddress::address(recipient);
+    let message = Message {
+        to: vec![recipient],
+        subject: String::from("mailgun-rs"),
+        html: String::from("<h1>hello from mailgun with attachments</h1>"),
+        ..Default::default()
+    };
+
+    let client = Mailgun {
+        api_key: String::from(key),
+        domain: String::from(domain),
+    };
+    let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
+    let attachments = vec!["/path/to/attachment-1.txt".to_string(), "/path/to/attachment-2.txt".to_string()];
+
+    match client.send(MailgunRegion::US, &sender, message, Some(attachments)) {
         Ok(_) => {
             println!("successful");
         }

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ fn send_html(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
+    let attachments = Vec::new();
 
-    match client.send(MailgunRegion::US, &sender, message) {
+    match client.send(MailgunRegion::US, &sender, message, attachments) {
         Ok(_) => {
             println!("successful");
         }
@@ -80,8 +81,9 @@ fn send_template(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
+    let attachments = Vec::new();
 
-    match client.send(MailgunRegion::US, &sender, message) {
+    match client.send(MailgunRegion::US, &sender, message, attachments) {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -1,9 +1,9 @@
 use dotenv::dotenv;
-use std::env;
-use std::collections::HashMap;
+use mailgun_rs::{EmailAddress, Mailgun, MailgunRegion, Message};
 use once_cell::sync::OnceCell;
+use std::collections::HashMap;
+use std::env;
 use std::sync::Mutex;
-use mailgun_rs::{EmailAddress, Mailgun, Message, MailgunRegion};
 
 static MAILGUN_CLIENT: OnceCell<Mutex<Mailgun>> = OnceCell::new();
 
@@ -27,7 +27,9 @@ fn initialize_mailgun(api_key: &str, domain: &str) {
         domain: domain.to_string(),
     };
 
-    MAILGUN_CLIENT.set(Mutex::new(mailgun_client)).expect("Mailgun client can only be initialized once");
+    MAILGUN_CLIENT
+        .set(Mutex::new(mailgun_client))
+        .expect("Mailgun client can only be initialized once");
 }
 
 async fn send_html(recipient: &str) {
@@ -40,12 +42,13 @@ async fn send_html(recipient: &str) {
     };
 
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
+    let attachments = Vec::new();
 
     if let Some(client) = MAILGUN_CLIENT.get() {
         let mailgun_client = client.lock().unwrap();
 
         match mailgun_client
-            .async_send(MailgunRegion::US, &sender, message)
+            .async_send(MailgunRegion::US, &sender, message, attachments)
             .await
         {
             Ok(_) => {
@@ -76,7 +79,12 @@ async fn send_template(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.async_send(MailgunRegion::US, &sender, message).await {
+    let attachments = Vec::new();
+
+    match client
+        .async_send(MailgunRegion::US, &sender, message, attachments)
+        .await
+    {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -42,13 +42,12 @@ async fn send_html(recipient: &str) {
     };
 
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
     if let Some(client) = MAILGUN_CLIENT.get() {
         let mailgun_client = client.lock().unwrap();
 
         match mailgun_client
-            .async_send(MailgunRegion::US, &sender, message, attachments)
+            .async_send(MailgunRegion::US, &sender, message, None)
             .await
         {
             Ok(_) => {
@@ -79,10 +78,9 @@ async fn send_template(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
     match client
-        .async_send(MailgunRegion::US, &sender, message, attachments)
+        .async_send(MailgunRegion::US, &sender, message, None)
         .await
     {
         Ok(_) => {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -26,7 +26,9 @@ fn send_html(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.send(MailgunRegion::US, &sender, message, Vec::new()) {
+    let attachments = Vec::new();
+
+    match client.send(MailgunRegion::US, &sender, message, attachments) {
         Ok(_) => {
             println!("successful");
         }
@@ -52,7 +54,9 @@ fn send_template(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.send(MailgunRegion::US, &sender, message, Vec::new()) {
+    let attachments = Vec::new();
+
+    match client.send(MailgunRegion::US, &sender, message, attachments) {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, fs, path::Path};
 
 use mailgun_rs::{EmailAddress, Mailgun, MailgunRegion, Message};
 use std::collections::HashMap;
@@ -10,6 +10,7 @@ fn main() {
 
     send_html(recipient, key, domain);
     send_template(recipient, key, domain);
+    send_with_attachment(recipient, key, domain);
 }
 
 fn send_html(recipient: &str, key: &str, domain: &str) {
@@ -25,7 +26,7 @@ fn send_html(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.send(MailgunRegion::US, &sender, message) {
+    match client.send(MailgunRegion::US, &sender, message, Vec::new()) {
         Ok(_) => {
             println!("successful");
         }
@@ -51,7 +52,45 @@ fn send_template(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    match client.send(MailgunRegion::US, &sender, message) {
+    match client.send(MailgunRegion::US, &sender, message, Vec::new()) {
+        Ok(_) => {
+            println!("successful");
+        }
+        Err(err) => {
+            println!("Error: {err}");
+        }
+    }
+}
+
+fn send_with_attachment(recipient: &str, key: &str, domain: &str) {
+    let recipient = EmailAddress::address(recipient);
+    let message = Message {
+        to: vec![recipient],
+        subject: String::from("mailgun-rs"),
+        html: String::from("<h1>hello from mailgun with attachment</h1>"),
+        ..Default::default()
+    };
+
+    let mut attachments = Vec::new();
+    for item in ["file-1", "file-2"] {
+        let file_name = format!("sample-{item}.txt");
+        let file_content = format!("hello from sample {item}");
+        fs::write(&file_name, &file_content).expect("cannot write file");
+
+        let absolute_path =
+            fs::canonicalize(Path::new(&file_name)).expect("cannot get absolute path");
+
+        attachments.push(absolute_path.to_string_lossy().to_string());
+    }
+
+    let client = Mailgun {
+        api_key: String::from(key),
+        domain: String::from(domain),
+    };
+
+    let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
+
+    match client.send(MailgunRegion::US, &sender, message, attachments) {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -26,9 +26,8 @@ fn send_html(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
-    match client.send(MailgunRegion::US, &sender, message, attachments) {
+    match client.send(MailgunRegion::US, &sender, message, None) {
         Ok(_) => {
             println!("successful");
         }
@@ -54,9 +53,8 @@ fn send_template(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
-    match client.send(MailgunRegion::US, &sender, message, attachments) {
+    match client.send(MailgunRegion::US, &sender, message, None) {
         Ok(_) => {
             println!("successful");
         }
@@ -94,7 +92,7 @@ fn send_with_attachment(recipient: &str, key: &str, domain: &str) {
 
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
 
-    match client.send(MailgunRegion::US, &sender, message, attachments) {
+    match client.send(MailgunRegion::US, &sender, message, Some(attachments)) {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/rocket/src/main.rs
+++ b/examples/rocket/src/main.rs
@@ -54,8 +54,12 @@ pub async fn save_order_async(order: Json<Order<'_>>) -> Json<MailConfirmation> 
 }
 
 fn send_mail_confirmation(order: &Json<Order<'_>>) {
-    let api_key = env::var("MAILGUN_PRIVATE_API_KEY").expect("MAILGUN_PRIVATE_API_KEY not set").to_string();
-    let domain = env::var("MAILGUN_DOMAIN").expect("MAILGUN_DOMAIN not set").to_string();
+    let api_key = env::var("MAILGUN_PRIVATE_API_KEY")
+        .expect("MAILGUN_PRIVATE_API_KEY not set")
+        .to_string();
+    let domain = env::var("MAILGUN_DOMAIN")
+        .expect("MAILGUN_DOMAIN not set")
+        .to_string();
 
     // send mail
     let recipient = EmailAddress::address(order.recipient);
@@ -71,8 +75,9 @@ fn send_mail_confirmation(order: &Json<Order<'_>>) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
+    let attachments = Vec::new();
 
-    match client.send(&sender, message) {
+    match client.send(MailgunRegion::US, &sender, message, attachments) {
         Ok(_) => {
             println!("successful");
         }
@@ -83,8 +88,12 @@ fn send_mail_confirmation(order: &Json<Order<'_>>) {
 }
 
 async fn send_mail_confirmation_async(order: &Json<Order<'_>>) {
-    let api_key = env::var("MAILGUN_PRIVATE_API_KEY").expect("MAILGUN_PRIVATE_API_KEY not set").to_string();
-    let domain = env::var("MAILGUN_DOMAIN").expect("MAILGUN_DOMAIN not set").to_string();
+    let api_key = env::var("MAILGUN_PRIVATE_API_KEY")
+        .expect("MAILGUN_PRIVATE_API_KEY not set")
+        .to_string();
+    let domain = env::var("MAILGUN_DOMAIN")
+        .expect("MAILGUN_DOMAIN not set")
+        .to_string();
 
     // send mail
     let recipient = EmailAddress::address(order.recipient);
@@ -100,8 +109,12 @@ async fn send_mail_confirmation_async(order: &Json<Order<'_>>) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
+    let attachments = Vec::new();
 
-    match client.async_send(&sender, message).await {
+    match client
+        .async_send(MailgunRegion::US, &sender, message, attachments)
+        .await
+    {
         Ok(_) => {
             println!("successful");
         }

--- a/examples/rocket/src/main.rs
+++ b/examples/rocket/src/main.rs
@@ -75,9 +75,8 @@ fn send_mail_confirmation(order: &Json<Order<'_>>) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
-    match client.send(MailgunRegion::US, &sender, message, attachments) {
+    match client.send(MailgunRegion::US, &sender, message, None) {
         Ok(_) => {
             println!("successful");
         }
@@ -109,10 +108,9 @@ async fn send_mail_confirmation_async(order: &Json<Order<'_>>) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@hackerth.com");
-    let attachments = Vec::new();
 
     match client
-        .async_send(MailgunRegion::US, &sender, message, attachments)
+        .async_send(MailgunRegion::US, &sender, message, None)
         .await
     {
         Ok(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,8 @@ pub struct Message {
     #[builder(default, setter(into))]
     pub html: String,
     #[builder(default, setter(into))]
+    pub attachment: String,
+    #[builder(default, setter(into))]
     pub template: String,
     #[builder(default)]
     pub template_vars: HashMap<String, String>,
@@ -143,6 +145,10 @@ impl Message {
 
         params.insert(String::from("text"), self.text);
         params.insert(String::from("html"), self.html);
+
+        if !self.attachment.is_empty() {
+            params.insert(String::from("attachment"), self.attachment);
+        }
 
         // add template
         if !self.template.is_empty() {
@@ -255,6 +261,7 @@ mod tests {
                 template: "template".to_string(),
                 template_vars: [("name".into(), "value".into())].iter().cloned().collect(),
                 template_json: None,
+                attachment: "".to_string(),
             }
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,16 @@ impl Mailgun {
         let client = reqwest::blocking::Client::new();
         let mut params = message.params();
         params.insert("from".to_string(), sender.to_string());
+
+        let mut form = reqwest::blocking::multipart::Form::new();
+
+        for (key, value) in params {
+            form = match key == "attachment" {
+                true => form.text(key, value),
+                false => form.file(key, value).expect("cannot set file"), // TODO
+            }
+        }
+
         let url = format!(
             "{}/{}/{}",
             get_base_url(region),
@@ -52,7 +62,7 @@ impl Mailgun {
         let res = client
             .post(url)
             .basic_auth("api", Some(self.api_key.clone()))
-            .form(&params)
+            .multipart(form)
             .send()?
             .error_for_status()?;
 
@@ -69,6 +79,16 @@ impl Mailgun {
         let client = reqwest::Client::new();
         let mut params = message.params();
         params.insert("from".to_string(), sender.to_string());
+
+        let mut form = reqwest::multipart::Form::new();
+
+        for (key, value) in params {
+            form = match key == "attachment" {
+                true => form.text(key, value),
+                false => form.file(key, value).await.expect("cannot set file"), // TODO
+            }
+        }
+
         let url = format!(
             "{}/{}/{}",
             get_base_url(region),
@@ -79,7 +99,7 @@ impl Mailgun {
         let res = client
             .post(url)
             .basic_auth("api", Some(self.api_key.clone()))
-            .form(&params)
+            .multipart(form)
             .send()
             .await?
             .error_for_status()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl Mailgun {
         region: MailgunRegion,
         sender: &EmailAddress,
         message: Message,
-        attachments: Vec<String>,
+        attachments: Option<Vec<String>>,
     ) -> SendResult<SendResponse> {
         let client = reqwest::blocking::Client::new();
         let mut params = message.params();
@@ -64,7 +64,7 @@ impl Mailgun {
             form = form.text(key, value);
         }
 
-        for path in attachments {
+        for path in attachments.unwrap_or_default() {
             form = form
                 .file("attachment", &path)
                 .map_err(|err| SendError::IoWithPath { path, source: err })?;
@@ -93,7 +93,7 @@ impl Mailgun {
         region: MailgunRegion,
         sender: &EmailAddress,
         message: Message,
-        attachments: Vec<String>,
+        attachments: Option<Vec<String>>,
     ) -> SendResult<SendResponse> {
         let client = reqwest::Client::new();
         let mut params = message.params();
@@ -105,7 +105,7 @@ impl Mailgun {
             form = form.text(key, value);
         }
 
-        for path in attachments {
+        for path in attachments.unwrap_or_default() {
             form = form
                 .file("attachment", &path)
                 .await


### PR DESCRIPTION
Hi there, thank you for creating and maintaining this library. It has been very helpful for me, as I'm using Mailgun and needed to connect to it using Rust. The library saved me a lot of time - so thank you!

While exploring the library, I noticed that it doesn't currently support sending emails with attachments. This PR aims to add that functionality. I've tested the feature locally and it works well, but please double-check everything on your end as well. 

This is my first open-source contribution and I'm not a Rust expert, so any feedback on the code is very welcome.

Changelogs:
- Added `attachments` support via function argument on `send` and `send_async`. This requires `multipart` and `stream` feature flag enabled for `reqwest`
- Added `thiserror` library to unify the error types
- Updated `examples/basic.rs`