### PR TITLE
New Attachment type for async_send

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,16 @@ fn send_html_with_attachment(recipient: &str, key: &str, domain: &str) {
         domain: String::from(domain),
     };
     let sender = EmailAddress::name_address("no-reply", "no-reply@huatuo.xyz");
-    let attachments = vec!["/path/to/attachment-1.txt".to_string(), "/path/to/attachment-2.txt".to_string()];
-
+    let attachments = vec![
+        Attachment::builder()
+            .path("/path/to/attachment-1.txt".to_string())
+            .attachment_type(AttachmentType::Attachment)
+            .build(),
+        Attachment::builder()
+            .path("/path/to/attachment-2.txt".to_string())
+            .attachment_type(AttachmentType::Inline)
+            .build(),
+    ];
     match client.send(MailgunRegion::US, &sender, message, Some(attachments)) {
         Ok(_) => {
             println!("successful");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,13 +151,13 @@ impl Mailgun {
                 AttachmentType::Inline => "inline",
             };
 
-            form =
-                form.file(field_name, &attachment.path)
-                    .await
-                    .map_err(|err| SendError::IoWithPath {
-                        path: attachment.path.clone(),
-                        source: err,
-                    })?;
+            form = form
+                .file(field_name, &attachment.path)
+                .await
+                .map_err(|err| SendError::IoWithPath {
+                    path: attachment.path.clone(),
+                    source: err,
+                })?;
         }
 
         let url = format!(


### PR DESCRIPTION
I need `async_send`, so this is a simple update to bring it the new `Attachment` type